### PR TITLE
Added a lame implementation seeddb.bin generation and use title key from decTitleKeys.bin

### DIFF
--- a/PlaiCDN.py
+++ b/PlaiCDN.py
@@ -640,11 +640,11 @@ if '' in dot3ds_command_array:
 
 if make_cia == 1:
     print('\nBuilding ' + title_id + '.cia...')
-    call(dotcia_command_array, stderr=STDOUT, shell=True)
+    call(dotcia_command_array, stderr=STDOUT)
 
 if make_3ds == 1:
     print('\nBuilding ' + title_id + '.3ds...')
-    call(dot3ds_command_array, stderr=STDOUT, shell=True)
+    call(dot3ds_command_array, stderr=STDOUT)
 
 if os.path.isfile('rom.rsf'):
     os.remove('rom.rsf')

--- a/PlaiCDN.py
+++ b/PlaiCDN.py
@@ -501,14 +501,15 @@ for i in range(content_count):
             ret_title_name_stripped, ret_region, ret_product_code, ret_publisher, ret_crypto_seed, ret_curr_version, ret_title_size = getTitleInfo((unhexlify(title_id)))
         except (KeyboardInterrupt, SystemExit):
             pass
-        with open(outsname, 'wb') as seeddb_handler:
-            seed_count = "1".rjust(2, "0").ljust(32, '0')
-            # Title_id is reversed in seeddb.bin
-            seed_title = "".join(reversed([title_id[i:i+2] for i in range(0, len(title_id), 2)]))
-            seed_crypto = ret_crypto_seed
-            seed = unhexlify((seed_count+seed_title+seed_crypto).ljust(96, '0'))
-            seeddb_handler.write(seed)
-            seeddb_handler.close()
+        if ret_crypto_seed != '':
+            with open(outsname, 'wb') as seeddb_handler:
+                seed_count = "1".rjust(2, "0").ljust(32, '0')
+                # Title_id is reversed in seeddb.bin
+                seed_title = "".join(reversed([title_id[i:i+2] for i in range(0, len(title_id), 2)]))
+                seed_crypto = ret_crypto_seed
+                seed = unhexlify((seed_count+seed_title+seed_crypto).ljust(96, '0'))
+                seeddb_handler.write(seed)
+                seeddb_handler.close()
     # if the content location does not exist, redown is set, or the size is incorrect redownload
     if os.path.exists(outfname) == 0 or force_download == 1 or os.path.getsize(outfname) != unpack('>Q', tmd_var[cOffs+8:cOffs+16])[0]:
         response = urllib.request.urlopen(base_url + '/' + cID)

--- a/PlaiCDN.py
+++ b/PlaiCDN.py
@@ -350,10 +350,27 @@ for i in range(len(sys.argv)):
     elif sys.argv[i] == '-nocia': make_cia = 0
     elif sys.argv[i] == '-check': checkKey = 1
 
-if len(title_key) != 32 or len(title_id) != 16:
+if (len(title_key) != 32 and not os.path.isfile('decTitleKeys.bin')) or len(title_id) != 16:
     print('Invalid arguments')
     raise SystemExit(0)
 
+# pull title key from decTitleKeys.bin if available
+if len(title_key) != 32 and os.path.isfile('decTitleKeys.bin'):
+    decryptedKeys = {}
+    with open('decTitleKeys.bin', 'rb') as file_handler:
+        nEntries = os.fstat(file_handler.fileno()).st_size / 32
+        file_handler.seek(16, os.SEEK_SET)
+        for i in range(int(nEntries)):
+            file_handler.seek(8, os.SEEK_CUR)
+            tmp_title_id = file_handler.read(8)
+            decryptedTitleKey = file_handler.read(16)
+            decryptedKeys.update({(hexlify(tmp_title_id)).decode() : (hexlify(decryptedTitleKey)).decode()})
+    try:
+        title_key = decryptedKeys[title_id]
+    except:
+        print('Title key not available in decTitleKeys.bin')
+        raise SystemExit(0)
+    
 # set CDN default URL
 base_url = 'http://ccs.cdn.c.shop.nintendowifi.net/ccs/download/' + title_id
 

--- a/PlaiCDN.py
+++ b/PlaiCDN.py
@@ -476,6 +476,22 @@ for i in range(content_count):
             raise SystemExit(0)
         print('\nTitlekey successfully verified to match title ID ' + title_id)
         raise SystemExit(0)
+    # if the content location does not exist, redown is set, or the size is incorrect for crypto seed
+    outsname = title_id + '/seeddb.bin'
+    if os.path.exists(outsname) == 0 or force_download == 1 or os.path.getsize(outsname) != 48:
+        try:
+            print("Checking for crypto seed (seeddb.bin will be generated if required).")
+            ret_title_name_stripped, ret_region, ret_product_code, ret_publisher, ret_crypto_seed, ret_curr_version, ret_title_size = getTitleInfo((unhexlify(title_id)))
+        except (KeyboardInterrupt, SystemExit):
+            pass
+        with open(outsname, 'wb') as seeddb_handler:
+            seed_count = "1".rjust(2, "0").ljust(32, '0')
+            # Title_id is reversed in seeddb.bin
+            seed_title = "".join(reversed([title_id[i:i+2] for i in range(0, len(title_id), 2)]))
+            seed_crypto = ret_crypto_seed
+            seed = unhexlify((seed_count+seed_title+seed_crypto).ljust(96, '0'))
+            seeddb_handler.write(seed)
+            seeddb_handler.close()
     # if the content location does not exist, redown is set, or the size is incorrect redownload
     if os.path.exists(outfname) == 0 or force_download == 1 or os.path.getsize(outfname) != unpack('>Q', tmd_var[cOffs+8:cOffs+16])[0]:
         response = urllib.request.urlopen(base_url + '/' + cID)

--- a/PlaiCDN.py
+++ b/PlaiCDN.py
@@ -88,7 +88,9 @@ def system_usage():
     print('-check    : checks if title id matches key')
     print('-checkbin : checks title keys from decTitleKeys.bin (games only)')
     print('-checkall : use with -checkbin, checks for all titles')
+    print('-seeddb   : use with -checkbin, generate seeddb for title keys in decTitleKeys.bin')
     print('-redown   : redownload content')
+    print('-seed     : generate corresponding seeddb file')
     print('-no3ds    : don\'t build 3DS file')
     print('-nocia    : don\'t build CIA file')
     raise SystemExit(0)
@@ -213,7 +215,7 @@ for i in range(len(sys.argv)):
         try:
             tmd_var = urllib.request.urlopen(base_url + '/tmd')
         except urllib.error.URLError as e:
-            print('Could not retrieve tmd; received error: ' + e)
+            print('Could not retrieve tmd; received error: ' + str(e))
             continue
         tmd_var = tmd_var.read()
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,22 @@ This script now pulls title metadata directly off the CDN by CLCert-A.
 **Requires [makerom](https://github.com/profi200/Project_CTR/releases), [ctr-common-1.crt](https://mega.nz/#!Rp9CDZSY!iDopFefUj2oZERWYHm3BDbEKDhmD363YVX24TCkwp50) ([mirror](https://drive.google.com/open?id=0BzPfvjeuhqoDcnhNcjNMWlV6MFk)), and [ctr-common-1.key](https://mega.nz/#!ZxdD1DKK!eksGHKw4psuouBN1y_yeh2x3eIvXyK1IHHMfs-vTJvs) ([mirror](https://drive.google.com/open?id=0BzPfvjeuhqoDd01oNUw4N0RpNFk)) to be in the directory**    
 ___
 
-Usage: `<title_id title_key [-redown -no3ds -nocia] or [-check]> or <title_id [-info]> or [-deckey] or [-checkbin -checkall]`    
-\-info     : used with just a title id to retrieve info from CDN    
-\-deckey   : print keys from decTitleKeys.bin    
-\-check    : checks if title id matches key    
-\-checkbin : checks title keys from decTitleKeys.bin (games only)    
-\-checkall : use with -checkbin, checks for all titles    
+Usage: PlaiCDN \<TitleID TitleKey\> \<Options\> to create your content    
 \-redown   : redownload content    
-\-nodown   : don't download content, just print links    
 \-no3ds    : don't build 3DS file    
 \-nocia    : don't build CIA file    
+\-nobuild  : don't build 3DS or CIA    
+\-nohash   : ignore hash checks    
+\-nowait   : no crypt message/waiting for input    
+
+Usage: PlaiCDN \<TitleID\> -info to display detailed metadata    
+
+Usage: PlaiCDN \<Options\> to print or check decTitleKeys.bin keys    
+\-deckey   : print keys from decTitleKeys.bin    
+\-check    : checks if title id matches key    
+\-checkbin : checks titlekeys from decTitleKeys.bin    
+\-checkall : check all titlekeys when using -checkbin    
+\-fast     : skips name retrieval when using -checkbin    
 
 ___
 


### PR DESCRIPTION
Reuses the getTitleInfo to obtain the 9.6 crypto seed for the specific title and generates a single seed seeddb.bin, if available, for use with Decrypt9 during decrypting.

When the title key isn't in the argument and a decTitleKeys.bin is available, reuses -deckey to create a dictionary of title_ids/title_keys and searches for the corresponding title_key to use.

Both aim to simplify process to requiring only the Title_ID and Decrypt9.