### PR TITLE
Add other common files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ctr-common-1.key
 ctr-common-1-cert.dec
 ctr-common-1-key.dec
 ctr-common-1.p12
+makerom
+makerom.exe
+rom.rsf


### PR DESCRIPTION
There are a few temporary files and common binaries suggested that are not currently ignored by gitignore. This PR adds those files.